### PR TITLE
Fjerner kafka-username og password fra conf,

### DIFF
--- a/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/Configuration.kt
+++ b/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/Configuration.kt
@@ -56,7 +56,6 @@ data class Configuration(val config : ApplicationConfig) {
 
         KafkaConfig(
             bootstrapServers = bootstrapServers,
-            credentials = Pair(config.getRequiredString("nav.kafka.username", secret = false), config.getRequiredString("nav.kafka.password", secret = true)),
             trustStore = trustStore,
             keyStore = keyStore
         )
@@ -64,10 +63,7 @@ data class Configuration(val config : ApplicationConfig) {
 
     internal fun getRedisPort() = config.getRequiredString("nav.redis.port", secret = false).toInt()
     internal fun getRedisHost() = config.getRequiredString("nav.redis.host", secret = false)
-
-    internal fun getStoragePassphrase(): String {
-        return config.getRequiredString("nav.storage.passphrase", secret = true)
-    }
+    internal fun getStoragePassphrase(): String = config.getRequiredString("nav.storage.passphrase", secret = true)
 
     internal fun<K, V>cache(
         expiry: Duration = Duration.ofMinutes(config.getRequiredString("nav.cache.barn.expiry_in_minutes", secret = false).toLong())

--- a/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/kafka/KafkaConfig.kt
@@ -12,15 +12,15 @@ import java.util.*
 
 private val logger: Logger = LoggerFactory.getLogger(KafkaConfig::class.java)
 private const val ID_PREFIX = "srv-omd-alene-api-"
+
 class KafkaConfig(
     bootstrapServers: String,
-    val credentials: Pair<String, String>,
     trustStore: Pair<String, String>?,
     keyStore: Pair<String, String>?
 ) {
     private val producer = Properties().apply {
         put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-        if(trustStore == null || keyStore == null) medCredentials(credentials) //For å skille mellom test/miljø
+        if(trustStore == null || keyStore == null) medCredentials(Pair("srvkafkaclient", "kafkaclient")) //For å skille mellom test/miljø
         medTrustStore(trustStore)
         medKeyStore(keyStore)
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -58,10 +58,6 @@ nav {
     kafka {
         bootstrap_servers = ""
         bootstrap_servers = ${?KAFKA_BROKERS}
-        username = ""
-        username = ${?SRV_USERNAME}
-        password = ""
-        password = ${?SRV_PASSWORD}
         truststore_path = ""
         truststore_path = ${?KAFKA_TRUSTSTORE_PATH}
         credstore_password = ""

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/KafkaWrapper.kt
@@ -73,9 +73,6 @@ internal fun KafkaConsumer<String, TopicEntry<JSONObject>>.hentSøknad(
     throw IllegalStateException("Fant ikke opprettet oppgave for søknad $søknadId etter $maxWaitInSeconds sekunder.")
 }
 
-fun KafkaEnvironment.username() = username
-fun KafkaEnvironment.password() = password
-
 private class SoknadV1OutgoingDeserialiser : Deserializer<TopicEntry<JSONObject>> {
     override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {}
     override fun deserialize(topic: String, data: ByteArray): TopicEntry<JSONObject> {

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/TestConfiguration.kt
@@ -49,8 +49,6 @@ object TestConfiguration {
         // Kafka
         kafkaEnvironment?.let {
             map["nav.kafka.bootstrap_servers"] = it.brokersURL
-            map["nav.kafka.username"] = it.username()
-            map["nav.kafka.password"] = it.password()
         }
 
         map["nav.redis.host"] = "localhost"


### PR DESCRIPTION
Fjerner kafka_username og passord fra conf. Setter de direkte dersom credentials skal brukes, altså i test. Ellers feiler den i miljø fordi srv secreten fjernes. 
Grei løsning?