### PR TITLE
Splitte per barn

### DIFF
--- a/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/Barn.kt
+++ b/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/Barn.kt
@@ -73,3 +73,4 @@ enum class TidspunktForAleneomsorg {
     SISTE_2_ÅRENE,
     TIDLIGERE
 }
+

--- a/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/SøknadService.kt
@@ -34,7 +34,7 @@ class SøknadService(
 
         if (søknad.barn.size > 1) {
             val søknader = søknad.splittTilKomplettSøknadPerBarn(søker)
-            LOGGER.info("Søknad splittet opp i ${søknader.size}. SøknadId:${søknad.søknadId} splittet ut til ${søknader.map { it.søknadId }}")
+            LOGGER.info("SøknadId:${søknad.søknadId} splittet ut til ${søknader.map { it.søknadId }}")
 
             søknader.forEach {
                 kafkaProducer.produserKafkamelding(søknad = it, metadata = metadata)
@@ -49,5 +49,8 @@ class SøknadService(
 fun Søknad.splittTilKomplettSøknadPerBarn(søker: Søker): List<KomplettSøknad> {
     return this.barn.mapIndexed { index, barn ->
         this.tilKomplettSøknad(søker).copy(barn = listOf(barn), søknadId = søknadId+"-${index+1}")
+    // TODO: 21/05/2021 Er det best å legge på -X på original uuid, eller burde man generere helt ny uuid?
+    //  Kan noe feile fordi den er 2 tegn lengre? Vi har uansett correlationId for å følge, samt logger hva de blir spilttet ut til.
+    // Fordelen med å legge på postfix er at det er enklere å teste fordi da kjenner man til søknadId.
     }
 }

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/ApplicationTest.kt
@@ -59,10 +59,11 @@ class ApplicationTest {
             val fileConfig = ConfigFactory.load()
             val testConfig = ConfigFactory.parseMap(
                 TestConfiguration.asMap(
-                kafkaEnvironment = kafkaEnvironment,
-                wireMockServer = wireMockServer,
-                redisServer = redisServer
-            ))
+                    kafkaEnvironment = kafkaEnvironment,
+                    wireMockServer = wireMockServer,
+                    redisServer = redisServer
+                )
+            )
             val mergedConfig = testConfig.withFallback(fileConfig)
 
             return HoconApplicationConfig(mergedConfig)
@@ -150,7 +151,7 @@ class ApplicationTest {
     }
 
     @Test
-    fun `Hente barn og sjekk eksplisit at identitetsnummer ikke blir med ved get kall`(){
+    fun `Hente barn og sjekk eksplisit at identitetsnummer ikke blir med ved get kall`() {
 
         val respons = requestAndAssert(
             httpMethod = HttpMethod.Get,
@@ -203,7 +204,7 @@ class ApplicationTest {
     }
 
     @Test
-    fun `Sende gyldig melding til validering`(){
+    fun `Sende gyldig melding til validering`() {
         val søknad = SøknadUtils.gyldigSøknad().somJson()
 
         requestAndAssert(
@@ -376,8 +377,12 @@ class ApplicationTest {
         return respons
     }
 
-    private fun hentSøknadSendtTilProsessering(soknadId: String): JSONObject {
-        return kafkaTestConsumer.hentSøknad(soknadId, topic = Topics.MOTTATT_OMD_ALENEOMSORG).data
+    private fun hentSøknadSendtTilProsessering(soknadId: String, forventetAntall: Int = 1): JSONObject {
+        return kafkaTestConsumer.hentSøknad(
+            soknadId,
+            topic = Topics.MOTTATT_OMD_ALENEOMSORG,
+            forventetAntall = forventetAntall
+        ).data
     }
 
     private fun verifiserAtInnholdetErLikt(
@@ -387,9 +392,10 @@ class ApplicationTest {
         assertTrue(søknadPlukketFraTopic.has("søker"))
         søknadPlukketFraTopic.remove("søker") //Fjerner søker siden det settes i komplettSøknad
 
-        søknadPlukketFraTopic.remove("k9Format") //Fjerner k9Format
+        søknadPlukketFraTopic.remove("barn")
+        søknadSendtInn.remove("barn")
 
-        JSONAssert.assertEquals(søknadSendtInn, søknadPlukketFraTopic,  true)
+        JSONAssert.assertEquals(søknadSendtInn, søknadPlukketFraTopic, true)
 
         logger.info("Verifisering OK")
     }

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/KafkaWrapper.kt
@@ -56,7 +56,8 @@ internal fun KafkaEnvironment.testConsumer() : KafkaConsumer<String, TopicEntry<
 internal fun KafkaConsumer<String, TopicEntry<JSONObject>>.hentSøknad(
     søknadId: String,
     maxWaitInSeconds: Long = 20,
-    topic: String
+    topic: String,
+    forventetAntall: Int
 ) : TopicEntry<JSONObject> {
     val end = System.currentTimeMillis() + Duration.ofSeconds(maxWaitInSeconds).toMillis()
     while (System.currentTimeMillis() < end) {
@@ -66,7 +67,7 @@ internal fun KafkaConsumer<String, TopicEntry<JSONObject>>.hentSøknad(
             .filter { it.key() == søknadId }
 
         if (entries.isNotEmpty()) {
-            assertEquals(1, entries.size)
+            assertEquals(forventetAntall, entries.size)
             return entries.first().value()
         }
     }


### PR DESCRIPTION
Det er ønskelig at det blir laget en søknad per barn selvom bruker bare skal sende inn en. Dette er en mulig løsning. 

Må vurderes:
- Skal vi postfixe søknadId med "-x" når vi splitter, eller skal vi generere nye UUID. Fordelen med postfix er at det er enklere å teste og tracking. Negativt er at da blir det ikke en gyldig UUID lenger fordi den for to ekstra tegn.
- Dersom noe feiler under kafka producer så kan det skje at feks 1 av 2 delsøknader blir registrert. Er det er problem? Søker får feil i dialogen og kan prøve å sende inn på nytt. Burde anta at saksbehandling håndterer duplikater dersom det kommer inn 2 søknader på samme person og samme barn?