### PR TITLE
Sette aktørId som påbudt og fiks test import

### DIFF
--- a/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/Barn.kt
+++ b/src/main/kotlin/no/nav/omsorgsdageraleneomsorgapi/søknad/Barn.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 data class Barn (
     val navn: String,
-    val aktørId: String?,
+    val aktørId: String,
     var identitetsnummer: String?,
     val tidspunktForAleneomsorg: TidspunktForAleneomsorg,
     val dato: LocalDate? = null

--- a/src/test/kotlin/SøknadSplittTest.kt
+++ b/src/test/kotlin/SøknadSplittTest.kt
@@ -14,21 +14,21 @@ class SøknadSplittTest {
             Barn(
                 navn = "Ole",
                 identitetsnummer = "25058118020",
-                aktørId = null,
+                aktørId = "12345",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2021-01-01")
             ),
             Barn(
                 navn = "Dole",
                 identitetsnummer = "19017822821",
-                aktørId = null,
+                aktørId = "12345",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2021-01-01")
             ),
             Barn(
                 navn = "Doffen",
                 identitetsnummer = "03127900263",
-                aktørId = null,
+                aktørId = "12345",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2021-01-01")
             )

--- a/src/test/kotlin/SøknadSplittTest.kt
+++ b/src/test/kotlin/SøknadSplittTest.kt
@@ -2,8 +2,8 @@ import no.nav.omsorgsdageraleneomsorgapi.SøknadUtils
 import no.nav.omsorgsdageraleneomsorgapi.søknad.Barn
 import no.nav.omsorgsdageraleneomsorgapi.søknad.TidspunktForAleneomsorg
 import no.nav.omsorgsdageraleneomsorgapi.søknad.splittTilSøknadPerBarn
-import org.junit.Test
 import java.time.LocalDate
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SøknadSplittTest {

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/ApplicationTest.kt
@@ -352,14 +352,14 @@ class ApplicationTest {
                 Barn(
                     navn = "Ole",
                     identitetsnummer = "25058118020",
-                    aktørId = null,
+                    aktørId = "12345",
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                     dato = LocalDate.parse("2021-01-01")
                 ),
                 Barn(
                     navn = "Doffen",
                     identitetsnummer = "03127900263",
-                    aktørId = null,
+                    aktørId = "12345",
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                     dato = LocalDate.parse("2021-01-01")
                 )

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/BarnValideringTest.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/BarnValideringTest.kt
@@ -4,8 +4,8 @@ import no.nav.helse.dusseldorf.ktor.core.ParameterType
 import no.nav.helse.dusseldorf.ktor.core.Violation
 import no.nav.omsorgsdageraleneomsorgapi.søknad.Barn
 import no.nav.omsorgsdageraleneomsorgapi.søknad.TidspunktForAleneomsorg
-import org.junit.Test
 import java.time.LocalDate
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class BarnValideringTest {

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/K9FormatTest.kt
@@ -2,11 +2,11 @@ package no.nav.omsorgsdageraleneomsorgapi
 
 import no.nav.k9.søknad.JsonUtils
 import no.nav.omsorgsdageraleneomsorgapi.k9format.tilK9Format
-import org.junit.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.*
+import kotlin.test.Test
 
 class K9FormatTest {
 

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/SøknadUtils.kt
@@ -25,7 +25,7 @@ object SøknadUtils {
             Barn(
                 navn = "Ole Dole",
                 identitetsnummer = "25058118020",
-                aktørId = null,
+                aktørId = "12345",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2021-01-01")
             )

--- a/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/SøknadValideringsTest.kt
+++ b/src/test/kotlin/no/nav/omsorgsdageraleneomsorgapi/SøknadValideringsTest.kt
@@ -3,7 +3,8 @@ package no.nav.omsorgsdageraleneomsorgapi
 import no.nav.helse.dusseldorf.ktor.core.Throwblem
 import no.nav.omsorgsdageraleneomsorgapi.felles.starterMedFodselsdato
 import no.nav.omsorgsdageraleneomsorgapi.søknad.valider
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import kotlin.test.Test
 import kotlin.test.assertTrue
 
 internal class SøknadValideringsTest {
@@ -19,25 +20,31 @@ internal class SøknadValideringsTest {
         SøknadUtils.gyldigSøknad().valider()
     }
 
-    @Test(expected = Throwblem::class)
+    @Test
     fun `Feiler dersom harForståttRettigheterOgPlikter er false`(){
-        SøknadUtils.gyldigSøknad().copy(
-            harForståttRettigheterOgPlikter = false
-        ).valider()
+        Assertions.assertThrows(Throwblem::class.java){
+            SøknadUtils.gyldigSøknad().copy(
+                harForståttRettigheterOgPlikter = false
+            ).valider()
+        }
     }
 
-    @Test(expected = Throwblem::class)
+    @Test
     fun `Feiler dersom harBekreftetOpplysninger er false`(){
-        SøknadUtils.gyldigSøknad().copy(
-            harBekreftetOpplysninger = false
-        ).valider()
+        Assertions.assertThrows(Throwblem::class.java){
+            SøknadUtils.gyldigSøknad().copy(
+                harBekreftetOpplysninger = false
+            ).valider()
+        }
     }
 
-    @Test(expected =  Throwblem::class)
+    @Test
     fun `Feiler dersom barn er tom liste`(){
-        SøknadUtils.gyldigSøknad().copy(
-            barn = listOf()
-        ).valider()
+        Assertions.assertThrows(Throwblem::class.java){
+            SøknadUtils.gyldigSøknad().copy(
+                barn = listOf()
+            ).valider()
+        }
     }
 
 }


### PR DESCRIPTION
Bruker kun barn fra oppslag, så kan sette aktørId som påbudt.

Fikser import slik at alle tester blir kjørt.